### PR TITLE
Show drop-down for bucket with filtering

### DIFF
--- a/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/device_details.json
+++ b/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/device_details.json
@@ -1032,6 +1032,46 @@
       {
         "allowCustomValue": false,
         "current": {
+          "text": "InfluxDB",
+          "value": "InfluxDB"
+        },
+        "hide": 2,
+        "name": "datasource",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "cameras",
+          "value": "cameras"
+        },
+        "description": "Case insensitive prefix for filtering buckets",
+        "hide": 2,
+        "name": "bucket_prefix",
+        "query": "cameras",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
+        "allowCustomValue": false,
+        "definition": "import \"strings\"\n\nbuckets()\n|> filter(fn: (r) => strings.hasPrefix(v: strings.toLower(v: r.name), prefix: \"${bucket_prefix}\"))\n|> sort(columns: [\"name\"])",
+        "hide": 0,
+        "label": "Source Bucket",
+        "name": "bucket",
+        "options": [],
+        "query": {
+          "query": "import \"strings\"\n\nbuckets()\n|> filter(fn: (r) => strings.hasPrefix(v: strings.toLower(v: r.name), prefix: \"${bucket_prefix}\"))\n|> sort(columns: [\"name\"])"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
           "text": [],
           "value": []
         },
@@ -1063,33 +1103,6 @@
         "query": "host",
         "skipUrlSync": true,
         "type": "constant"
-      },
-      {
-        "allowCustomValue": false,
-        "current": {
-          "text": "InfluxDB",
-          "value": "InfluxDB"
-        },
-        "hide": 2,
-        "name": "datasource",
-        "options": [],
-        "query": "influxdb",
-        "refresh": 1,
-        "regex": "",
-        "type": "datasource"
-      },
-      {
-        "allowCustomValue": false,
-        "definition": "buckets()",
-        "hide": 2,
-        "name": "bucket",
-        "options": [],
-        "query": {
-          "query": "buckets()"
-        },
-        "refresh": 1,
-        "regex": "",
-        "type": "query"
       }
     ]
   },

--- a/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/overview_of_devices.json
+++ b/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/overview_of_devices.json
@@ -90,7 +90,7 @@
                   {
                     "targetBlank": true,
                     "title": "Device detail link",
-                    "url": "/d/${device_details_uid:raw}/device-details?var-device=${__value.text}"
+                    "url": "/d/${device_details_uid:raw}/device-details?var-bucket=${bucket}&var-device=${__value.text}"
                   }
                 ]
               }
@@ -414,7 +414,7 @@
                   {
                     "targetBlank": true,
                     "title": "Device detail link",
-                    "url": "/d/${device_details_uid:raw}/device-details?var-device=${__value.text}"
+                    "url": "/d/${device_details_uid:raw}/device-details?var-bucket=${bucket}&var-device=${__value.text}"
                   }
                 ]
               },
@@ -971,17 +971,29 @@
         "type": "datasource"
       },
       {
+        "current": {
+          "text": "cameras",
+          "value": "cameras"
+        },
+        "description": "Case insensitive prefix for filtering buckets",
+        "hide": 2,
+        "name": "bucket_prefix",
+        "query": "cameras",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
         "datasource": {
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "buckets()",
-        "hide": 2,
-        "label": "Database",
+        "definition": "import \"strings\"\n\nbuckets()\n|> filter(fn: (r) => strings.hasPrefix(v: strings.toLower(v: r.name), prefix: \"${bucket_prefix}\"))\n|> sort(columns: [\"name\"])",
+        "hide": 0,
+        "label": "Source Bucket",
         "name": "bucket",
         "options": [],
         "query": {
-          "query": "buckets()"
+          "query": "import \"strings\"\n\nbuckets()\n|> filter(fn: (r) => strings.hasPrefix(v: strings.toLower(v: r.name), prefix: \"${bucket_prefix}\"))\n|> sort(columns: [\"name\"])"
         },
         "refresh": 1,
         "regex": "",

--- a/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/system_overview.json
+++ b/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/system_overview.json
@@ -185,7 +185,7 @@
                   {
                     "targetBlank": true,
                     "title": "Device detail link",
-                    "url": "/d/${device_details_uid:raw}/device-details?var-device=${__value.text}&from=now-90d"
+                    "url": "/d/${device_details_uid:raw}/device-details?var-bucket=${bucket}&var-device=${__value.text}&from=now-90d"
                   }
                 ]
               }
@@ -440,7 +440,7 @@
                   {
                     "targetBlank": true,
                     "title": "Device details link",
-                    "url": "/d/${device_details_uid:raw}/device-details?var-device=${__value.text}"
+                    "url": "/d/${device_details_uid:raw}/device-details?var-bucket=${bucket}&var-device=${__value.text}"
                   }
                 ]
               }
@@ -642,7 +642,7 @@
                   {
                     "targetBlank": true,
                     "title": "Device Detail Link",
-                    "url": "/d/${device_details_uid:raw}/device-details?var-device=${__value.text}"
+                    "url": "/d/${device_details_uid:raw}/device-details?var-bucket=${bucket}&var-device=${__value.text}"
                   }
                 ]
               }
@@ -874,18 +874,30 @@
         "type": "datasource"
       },
       {
+        "current": {
+          "text": "cameras",
+          "value": "cameras"
+        },
+        "description": "Case insensitive prefix for filtering buckets",
+        "hide": 2,
+        "name": "bucket_prefix",
+        "query": "cameras",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
         "allowCustomValue": false,
         "datasource": {
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "buckets()",
-        "hide": 2,
-        "label": "Database",
+        "definition": "import \"strings\"\n\nbuckets()\n|> filter(fn: (r) => strings.hasPrefix(v: strings.toLower(v: r.name), prefix: \"${bucket_prefix}\"))\n|> sort(columns: [\"name\"])",
+        "hide": 0,
+        "label": "Source Bucket",
         "name": "bucket",
         "options": [],
         "query": {
-          "query": "buckets()"
+          "query": "import \"strings\"\n\nbuckets()\n|> filter(fn: (r) => strings.hasPrefix(v: strings.toLower(v: r.name), prefix: \"${bucket_prefix}\"))\n|> sort(columns: [\"name\"])"
         },
         "refresh": 1,
         "regex": "",


### PR DESCRIPTION
- Update bucket variables in all three dashboards to filter buckets to only show those starting with 'Cameras' (case insensitive) and sort them alphabetically.
- Show the variable as a drop down in the dashboards

This makes it possible to use multiple different buckets for segmentation of different data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboards now include a visible "Source Bucket" selector (label changed from "Database") that is populated via a Flux query.
  * Added a hidden "bucket_prefix" constant (default "cameras") to filter buckets by case‑insensitive prefix; bucket list is sorted.
  * Device detail links now include the selected bucket so panels navigate with bucket context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->