### PR TITLE
Fix bug breaking links in Overview of Devices

### DIFF
--- a/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/overview_of_devices.json
+++ b/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/overview_of_devices.json
@@ -81,7 +81,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "${unique_identifier}"
+              "options": "Device"
             },
             "properties": [
               {
@@ -405,7 +405,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "${unique_identifier}"
+              "options": "Device"
             },
             "properties": [
               {
@@ -1194,5 +1194,5 @@
   "timezone": "browser",
   "title": "Overview of Devices",
   "uid": "ceh7yyrnarj7kd",
-  "version": 30
+  "version": 31
 }


### PR DESCRIPTION
This was introduced in PR #19 when removing some renaming transformations, but these columns are still renamed to Device meaning that we should not have changed the matcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Overview of Devices dashboard to use a consistent “Device” label for field overrides, ensuring reliable matching and uniform display across panels and visualizations.

* **Chores**
  * Incremented the dashboard version to 31 to reflect the latest updates and facilitate deployment tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->