### PR TITLE
Infinite time for schema searches

### DIFF
--- a/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/device_details.json
+++ b/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/device_details.json
@@ -1077,13 +1077,13 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\nschema.tagValues(\n  bucket: \"${bucket}\",\n  tag: \"host\",\n)",
+        "definition": "import \"influxdata/influxdb/schema\"\nschema.tagValues(\n  bucket: \"${bucket}\",\n  tag: \"host\",\n  start: 1970-01-01T00:00:00Z\n)",
         "label": "Device",
         "multi": true,
         "name": "device",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\nschema.tagValues(\n  bucket: \"${bucket}\",\n  tag: \"host\",\n)"
+          "query": "import \"influxdata/influxdb/schema\"\nschema.tagValues(\n  bucket: \"${bucket}\",\n  tag: \"host\",\n  start: 1970-01-01T00:00:00Z\n)"
         },
         "refresh": 1,
         "regex": "",
@@ -1112,5 +1112,5 @@
   "timezone": "browser",
   "title": "Device Details",
   "uid": "bekds38txl1j4c",
-  "version": 35
+  "version": 36
 }

--- a/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/overview_of_devices.json
+++ b/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/overview_of_devices.json
@@ -1001,7 +1001,7 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"${unique_identifier}\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"${unique_identifier}\", start: 1970-01-01T00:00:00Z)",
         "description": "All devices that are known in the schema",
         "includeAll": true,
         "label": "Device",
@@ -1009,7 +1009,7 @@
         "name": "device",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"${unique_identifier}\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"${unique_identifier}\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1026,7 +1026,7 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"area\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"area\", start: 1970-01-01T00:00:00Z)",
         "description": "top-most level (e.g., Europe)",
         "includeAll": true,
         "label": "Area",
@@ -1034,7 +1034,7 @@
         "name": "area",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"area\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"area\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1051,7 +1051,7 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"geography\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"geography\", start: 1970-01-01T00:00:00Z)",
         "description": "sub division of Area (e.g., Sweden)",
         "includeAll": true,
         "label": "Geography",
@@ -1059,7 +1059,7 @@
         "name": "geography",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"geography\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"geography\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1076,7 +1076,7 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"region\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"region\", start: 1970-01-01T00:00:00Z)",
         "description": "Subdivision of Geography (e.g., Stockholm)",
         "includeAll": true,
         "label": "Region",
@@ -1084,7 +1084,7 @@
         "name": "region",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"region\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"region\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1101,7 +1101,7 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"site\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"site\", start: 1970-01-01T00:00:00Z)",
         "description": "bottom-most level (e.g., Friends Arena)",
         "includeAll": true,
         "label": "Site",
@@ -1109,7 +1109,7 @@
         "name": "site",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"site\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"site\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1126,14 +1126,14 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"type\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"type\", start: 1970-01-01T00:00:00Z)",
         "includeAll": true,
         "label": "Type",
         "multi": true,
         "name": "type",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"type\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"type\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1158,7 +1158,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"product_full_name\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"product_full_name\", start: 1970-01-01T00:00:00Z)",
         "description": "Model of the camera",
         "includeAll": true,
         "label": "Model Name",
@@ -1166,7 +1166,7 @@
         "name": "model",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"product_full_name\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"product_full_name\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1194,5 +1194,5 @@
   "timezone": "browser",
   "title": "Overview of Devices",
   "uid": "ceh7yyrnarj7kd",
-  "version": 31
+  "version": 32
 }

--- a/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/system_overview.json
+++ b/dashboard-deployments/system-monitoring-influxdb2-flux-grafana/provisioning/dashboards/system_overview.json
@@ -914,7 +914,7 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"area\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"area\", start: 1970-01-01T00:00:00Z)",
         "description": "top-most level (e.g., Europe)",
         "includeAll": true,
         "label": "Area",
@@ -922,7 +922,7 @@
         "name": "area",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"area\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"area\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -939,7 +939,7 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"geography\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"geography\", start: 1970-01-01T00:00:00Z)",
         "description": "sub division of Area (e.g., Sweden)",
         "includeAll": true,
         "label": "Geography",
@@ -947,7 +947,7 @@
         "name": "geography",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"geography\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"geography\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -964,7 +964,7 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"region\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"region\", start: 1970-01-01T00:00:00Z)",
         "description": "Subdivision of Geography (e.g., Stockholm)",
         "includeAll": true,
         "label": "Region",
@@ -972,7 +972,7 @@
         "name": "region",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"region\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"region\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -989,7 +989,7 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"site\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"site\", start: 1970-01-01T00:00:00Z)",
         "description": "bottom-most level (e.g., Friends Arena)",
         "includeAll": true,
         "label": "Site",
@@ -997,7 +997,7 @@
         "name": "site",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"site\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"site\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1014,14 +1014,14 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"type\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"type\", start: 1970-01-01T00:00:00Z)",
         "includeAll": true,
         "label": "Type",
         "multi": true,
         "name": "type",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"type\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"type\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1038,7 +1038,7 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"${unique_identifier}\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"${unique_identifier}\", start: 1970-01-01T00:00:00Z)",
         "description": "",
         "includeAll": true,
         "label": "Device",
@@ -1046,7 +1046,7 @@
         "name": "device",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"${unique_identifier}\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"${unique_identifier}\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1076,14 +1076,14 @@
           "type": "influxdb",
           "uid": "${datasource}"
         },
-        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"product_full_name\")",
+        "definition": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"product_full_name\", start: 1970-01-01T00:00:00Z)",
         "includeAll": true,
         "label": "Model Name",
         "multi": true,
         "name": "model",
         "options": [],
         "query": {
-          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"product_full_name\")"
+          "query": "import \"influxdata/influxdb/schema\"\n\nschema.tagValues(bucket: \"${bucket}\", tag: \"product_full_name\", start: 1970-01-01T00:00:00Z)"
         },
         "refresh": 1,
         "regex": "",
@@ -1159,5 +1159,5 @@
   "timezone": "browser",
   "title": "System Overview",
   "uid": "dsdsadfg3t3t3",
-  "version": 27
+  "version": 28
 }


### PR DESCRIPTION
When selecting the options for dropdowns in the menu, we want to find all the devices and properties in the database schema. By default, a schema search is limited in time. This removes the limitation by starting at epoch time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded variable dropdowns across Device Details, Overview of Devices, and System Overview dashboards by retrieving tag values from the earliest timestamp. This provides more complete and consistent filter options (e.g., device, model, area, region, site, type).
* **Chores**
  * Bumped dashboard versions to reflect updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->