### PR TITLE
Add files for time-in-area telemetry

### DIFF
--- a/project-time-in-area-analytics/config_output_time_in_area.conf
+++ b/project-time-in-area-analytics/config_output_time_in_area.conf
@@ -1,0 +1,59 @@
+# Processor for duplicating detection frame metrics
+#
+# This processor duplicates detection frame metrics.
+# This is necessary in some cases where we need to consume the
+# "detection_frame_with_duration" either from two processors or
+# from a processor and an output.
+#
+# Input: detection_frame_with_duration metrics with time_in_area_seconds field
+# Output: two copies of detection_frame_with_duration (detection_frame_with_duration and time_in_area_frame)
+#
+
+[[processors.starlark]]
+  # Process only detection frames with duration calculated
+  namepass = ["detection_frame_with_duration"]
+
+  source = '''
+def apply(metric):
+    # Duplicate the metric
+    time_in_area_frame = deepcopy(metric)
+    time_in_area_frame.name = "time_in_area_frame"
+
+    return [metric, time_in_area_frame]
+'''
+
+# InfluxDB Output Configuration for Time in Area Metrics
+#
+# This configuration sends information about object detections.
+# These metrics include time in area information such as total track time, object type,
+# track ID, and bounding box coordinates.
+#
+# Environment Variables for InfluxDB:
+# - INFLUX_HOST: InfluxDB server host (required)
+# - INFLUX_PORT: InfluxDB server port (required)
+# - INFLUX_TOKEN: InfluxDB API token for authentication (required)
+# - INFLUX_ORG: InfluxDB organization name (required)
+# - INFLUX_BUCKET: InfluxDB bucket name for storing metrics (required)
+#
+# Metric Fields Included (these fields are from the detection_frame_with_duration metric,
+# which this file is receiving a copy of):
+# - time_in_area_seconds: Total time the object has been tracked in the area (float)
+# - track_id: Unique identifier for the object track (string)
+# - object_type: Type/class of the detected object, e.g., "Human", "Vehicle" (string)
+# - timestamp: Original detection timestamp from the camera (string)
+# - frame: Frame timestamp from the analytics system (string)
+# - bounding_box_left: Left coordinate of bounding box (float, range 0.0 to 1.0, where 0.0 is the left edge of the frame and 1.0 is the right edge of the frame)
+# - bounding_box_right: Right coordinate of bounding box (float, range 0.0 to 1.0, where 0.0 is the left edge of the frame and 1.0 is the right edge of the frame)
+# - bounding_box_top: Top coordinate of bounding box (float, range 0.0 to 1.0, where 0.0 is the top edge of the frame and 1.0 is the bottom edge of the frame)
+# - bounding_box_bottom: Bottom coordinate of bounding box (float, range 0.0 to 1.0, where 0.0 is the top edge of the frame and 1.0 is the bottom edge of the frame)
+#
+# Measurement Name:
+# Metrics will be written to the "time_in_area_frame" measurement in InfluxDB,
+# using the InfluxDB configuration set in the FixedIT Data Agent's settings.
+[[outputs.influxdb_v2]]
+  namepass = ["time_in_area_frame"]
+
+  urls = ["${INFLUX_HOST}:${INFLUX_PORT}"]
+  token = "${INFLUX_TOKEN}"
+  organization = "${INFLUX_ORG}"
+  bucket = "${INFLUX_BUCKET}"

--- a/project-time-in-area-analytics/track_duration_calculator.star
+++ b/project-time-in-area-analytics/track_duration_calculator.star
@@ -52,7 +52,11 @@ def get_time_in_area_seconds(track_id, current_seconds, track_state):
             "last_seen_seconds": current_seconds
         }
         log.debug("get_time_in_area_seconds: track_id=" + track_id + " first detection at " + str(current_seconds))
-        return 0  # Time in area is 0 on first detection
+        # Time in area is 0 on first detection.
+        # We set it to 0.0 since subsequent values will be floats,
+        # and 0 gets interpreted as an integer, which can result in
+        # errors when sending metrics to InfluxDB.
+        return 0.0
 
     # Update last seen time
     track_state[track_id]["last_seen_seconds"] = current_seconds


### PR DESCRIPTION
This commit adds config files for sending time-in-area metrics to InfluxDB. Since we do not want to alter the files that make up the original processor pipeline, this commit adds an extra processor file (config_process_duplicate_detection_drames.conf) which duplicates the necessary metric for the new output (config_output_tracks.conf) to receive. These files can optionally be added to the combined config file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional InfluxDB export path to send time-in-area metrics (time_in_area_frame) separately for telemetry.

* **Documentation**
  * Updated README, Quick Setup, TOC and troubleshooting to show how to include the optional config, where to insert it when combining configs, and required InfluxDB environment variables.
  * Added a section describing exported metric fields and measurement name.

* **Bug Fixes**
  * Emit time-in-area values as floats for analytics compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->