### PR TITLE
Fix timestamp for time-in-area metrics

### DIFF
--- a/project-time-in-area-analytics/config_input_scene_detections.conf
+++ b/project-time-in-area-analytics/config_input_scene_detections.conf
@@ -42,3 +42,45 @@
 
   # String fields that should be preserved as strings during JSON parsing
   json_string_fields = ["timestamp", "track_id", "object_type", "frame"]
+
+# This processor sets the metric time from the timestamp field for all detection_frame metrics.
+# This ensures all downstream metrics use the detection's timestamp instead of the processing time.
+#
+# Input: detection_frame metrics from input
+# Output: Same metrics with metric.time set from timestamp field
+
+[[processors.starlark]]
+  namepass = ["detection_frame"]
+
+  source = '''
+load("time.star", "time")
+
+def utc_string_to_epoch_nanoseconds(s):
+    # Returns nanoseconds since Unix epoch (UTC).
+    # Accepts RFC3339/RFC3339Nano strings like "2024-01-15T14:30:45.123456Z"
+    if s == None or type(s) != type(""):
+        return 0
+
+    # Use catch() so a bad timestamp doesn't kill the script and drop metrics
+    err = catch(lambda: time.parse_time(s))
+    if err != None:
+        return 0
+
+    t = time.parse_time(s)  # defaults: RFC3339 + UTC
+    # Telegraf time values are nanoseconds since epoch
+    return t.unix_nano
+
+def apply(metric):
+    # Extract timestamp from metric fields
+    timestamp = metric.fields.get("timestamp")
+    if timestamp != None:
+        # Convert timestamp string to nanoseconds since epoch,
+        # since that is what metric.time expects
+        timestamp_nanoseconds = utc_string_to_epoch_nanoseconds(timestamp)
+
+        if timestamp_nanoseconds > 0:
+            metric.time = timestamp_nanoseconds
+
+    # Return the metric with updated time
+    return metric
+'''

--- a/project-time-in-area-analytics/config_input_scene_detections.conf
+++ b/project-time-in-area-analytics/config_input_scene_detections.conf
@@ -43,44 +43,6 @@
   # String fields that should be preserved as strings during JSON parsing
   json_string_fields = ["timestamp", "track_id", "object_type", "frame"]
 
-# This processor sets the metric time from the timestamp field for all detection_frame metrics.
-# This ensures all downstream metrics use the detection's timestamp instead of the processing time.
-#
-# Input: detection_frame metrics from input
-# Output: Same metrics with metric.time set from timestamp field
-
-[[processors.starlark]]
-  namepass = ["detection_frame"]
-
-  source = '''
-load("time.star", "time")
-
-def utc_string_to_epoch_nanoseconds(s):
-    # Returns nanoseconds since Unix epoch (UTC).
-    # Accepts RFC3339/RFC3339Nano strings like "2024-01-15T14:30:45.123456Z"
-    if s == None or type(s) != type(""):
-        return 0
-
-    # Use catch() so a bad timestamp doesn't kill the script and drop metrics
-    err = catch(lambda: time.parse_time(s))
-    if err != None:
-        return 0
-
-    t = time.parse_time(s)  # defaults: RFC3339 + UTC
-    # Telegraf time values are nanoseconds since epoch
-    return t.unix_nano
-
-def apply(metric):
-    # Extract timestamp from metric fields
-    timestamp = metric.fields.get("timestamp")
-    if timestamp != None:
-        # Convert timestamp string to nanoseconds since epoch,
-        # since that is what metric.time expects
-        timestamp_nanoseconds = utc_string_to_epoch_nanoseconds(timestamp)
-
-        if timestamp_nanoseconds > 0:
-            metric.time = timestamp_nanoseconds
-
-    # Return the metric with updated time
-    return metric
-'''
+  # Use the detection's own timestamp as the metric time instead of processing time
+  json_time_key    = "timestamp"
+  json_time_format = "RFC3339Nano"


### PR DESCRIPTION
This commit fixes the time-in-area metric timestamp to be the timestamp from the camera's metadata instead of the metric creation time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Detection event timestamps are now explicitly extracted, validated, and applied to analytics metrics so metrics reflect the original detection time.
  * String fields (timestamp, track_id, object_type, frame) are preserved.
  * Downstream time fields for detection-based metrics use the detection timestamp; non-detection metrics retain prior behavior.
  * No other input/output behaviors were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->