### PR TITLE
Updates to the the timelapse examples

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -64,7 +64,7 @@ reviews:
         - Use visual diagrams (mermaid) to explain system flows
         - Emphasize "no C/C++ development required" value proposition
         - Include comprehensive table of contents with proper anchor links
-        - Template values for environment variables should use format like `VAPIX_PASS="your_vapix_password"`
+        - Template values for environment variables should use format like `VAPIX_PASSWORD="your_vapix_password"`
         - In bash commands, use format like `--bucket <my_s3_bucket_name>` for template values
         - When using credentials, specify minimum required privileges (e.g., viewer/operator/admin) and
           encourage not using higher than needed

--- a/README.md
+++ b/README.md
@@ -128,23 +128,47 @@ The following diagram shows the data flow of the "Timelapse with AWS S3 Upload" 
 
 ```mermaid
 flowchart TD
-    A["⏳ Wait<br/>Sleep for interval"] --> B1["📥 VAPIX API Call<br/>Fetch JPEG image"]
-    B3 --> C["☁️ AWS S3<br/>Upload with local buffer"]
-    C --> A
+    A["⏳ Interval<br/>Trigger capture"] --> B1["📥 VAPIX API Call<br/>Fetch JPEG image"]
+    B4 --> J["☁️ S3<br/>.jpg object"]
+    B5 --> M["☁️ S3<br/>.json metadata"]
+
+    GT["📌 Telegraf:<br/>[global_tags]"]
+
+    XMeta["DEVICE_PROP_*<br/>AREA, SITE, GEO, …<br/>APP_VERSION, …"]
+    XMeta --> GT
+
+    XVapix["VAPIX_USERNAME<br/>VAPIX_PASSWORD"]
+    XVapix --> B1
+
+    XAws["AWS_ACCESS_KEY_ID<br/>AWS_SECRET_ACCESS_KEY<br/>AWS_REGION<br/>S3_BUCKET"]
+    XAws --> B4
+    XAws --> B5
 
     subgraph "axis_image_consumer.sh"
-        B1["📥 VAPIX API Call<br/>Fetch JPEG image"] --> B2["🔄 Base64 Encode<br/>Convert to text string"]
-        B2 --> B3["📤 Output Metric<br/>Structured JSON data"]
+        B1["📥 VAPIX API Call<br/>Fetch JPEG image"] --> B2["🔄 Base64 Encode<br/>Metric field only"]
+        B2 --> B3["📤 Exec metric<br/>image field + resolution tag"]
+    end
+
+    subgraph "outputs.remotefile (×2)"
+        B3 --> B4["Template:<br/>b64dec → JPEG bytes"]
+        B3 --> B5["Template:<br/>metadata JSON"]
     end
 
     style A fill:#f1f8e9
-    style C fill:#e8f5e8
+    style GT fill:#f3e5f5
+    style J fill:#e8f5e8
+    style M fill:#e8f5e8
     style B1 fill:#fff3e0
     style B2 fill:#fff3e0
     style B3 fill:#fff3e0
+    style B4 fill:#e3f2fd
+    style B5 fill:#e3f2fd
+    style XMeta fill:#f5f5f5,stroke:#9e9e9e
+    style XVapix fill:#f5f5f5,stroke:#9e9e9e
+    style XAws fill:#f5f5f5,stroke:#9e9e9e
 ```
 
-The system leverages the FixedIT Data Agent's built-in capabilities to create sophisticated data workflow graphs without traditional embedded programming. This shows that it is possible to work with binary data such as images and video in the FixedIT Data Agent, it also shows how to use the AWS S3 output integration in the FixedIT Data Agent.
+The system leverages the FixedIT Data Agent's built-in capabilities to create sophisticated data workflow graphs without traditional embedded programming. Frames are transported through Telegraf as base64 inside a metric; two remotefile sinks write the same basename JPEG plus a lightweight JSON metadata file with timestamps and tags. This also demonstrates the AWS S3 output integration via the Telegraf remotefile plugin.
 
 ## Developer Tools
 

--- a/project-timelapse-s3/README.md
+++ b/project-timelapse-s3/README.md
@@ -8,27 +8,53 @@ _Click the image above to watch the timelapse video on YouTube_
 
 ## How It Works
 
-The system captures images at regular intervals and uploads them to AWS S3 with timestamped filenames, creating a chronological sequence perfect for timelapse generation. Images are encoded as base64 strings within JSON files due to the Telegraf data format limitations. Telegraf does not generally support binary data, so base64 encoding is used as a workaround. The [remotefile](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/remotefile/README.md) plugin only supports structured data, therefore the files are saved as json files with the base64 encoded image in them.
+The system captures images at regular intervals and uploads them to AWS S3 with timestamped filenames, creating a chronological sequence perfect for timelapse generation.
+
+Since Telegraf in the Data Agent automatically handles buffering if an output is not available, you don't need to worry about losing frames if the device is offline for a short time. They will simply be buffered in memory and uploaded when the connection is restored. In this particular example, the buffering works a little differently than usual since the `remotefile` output will accept metrics even if the remote connection is temporarily unavailable, it will buffer these internally until the connection is restored. Internally in the `remotefile` plugin, `rsync` is used to upload the files to the S3 bucket. This means that you can change to uploading the images to e.g. an SFTP server by changing the remote URL.
+
+JPEGs are fetched from the camera, then internally represented as a [base64 string](https://en.wikipedia.org/wiki/Base64) inside Telegraf. Two [remotefile](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/remotefile/README.md) outputs receive the same metric: one uses `data_format = "template"` and `b64dec` to write a binary image file (`.jpg`); the other writes a small `.json` metadata file with `timestamp` and tags copied from the metric. This works around the standardized format for Telegraf metrics not carrying raw binary fields.
 
 ```mermaid
 flowchart TD
-    A["⏳ Wait<br/>Sleep for interval"] --> B1["📥 VAPIX API Call<br/>Fetch JPEG image"]
-    B3 --> C["☁️ AWS S3<br/>Upload with local buffer"]
-    C --> A
+    A["⏳ Interval<br/>Trigger capture"] --> B1["📥 VAPIX API Call<br/>Fetch JPEG image"]
+    B4 --> J["☁️ S3<br/>.jpg object"]
+    B5 --> M["☁️ S3<br/>.json metadata"]
+
+    GT["📌 Telegraf:<br/>[global_tags]"]
+
+    XMeta["DEVICE_PROP_*<br/>AREA, SITE, GEO, …<br/>APP_VERSION, …"]
+    XMeta --> GT
+
+    XVapix["VAPIX_USERNAME<br/>VAPIX_PASSWORD"]
+    XVapix --> B1
+
+    XAws["AWS_ACCESS_KEY_ID<br/>AWS_SECRET_ACCESS_KEY<br/>AWS_REGION<br/>S3_BUCKET"]
+    XAws --> B4
+    XAws --> B5
 
     subgraph "axis_image_consumer.sh"
-        B1["📥 VAPIX API Call<br/>Fetch JPEG image"] --> B2["🔄 Base64 Encode<br/>Convert to text string"]
-        B2 --> B3["📤 Output Metric<br/>Structured JSON data"]
+        B1["📥 VAPIX API Call<br/>Fetch JPEG image"] --> B2["🔄 Base64 Encode<br/>Metric field only"]
+        B2 --> B3["📤 Exec metric<br/>image field + resolution tag"]
+    end
+
+    subgraph "outputs.remotefile (×2)"
+        B3 --> B4["Template:<br/>b64dec → JPEG bytes"]
+        B3 --> B5["Template:<br/>metadata JSON"]
     end
 
     style A fill:#f1f8e9
-    style C fill:#e8f5e8
+    style GT fill:#f3e5f5
+    style J fill:#e8f5e8
+    style M fill:#e8f5e8
     style B1 fill:#fff3e0
     style B2 fill:#fff3e0
     style B3 fill:#fff3e0
+    style B4 fill:#e3f2fd
+    style B5 fill:#e3f2fd
+    style XMeta fill:#f5f5f5,stroke:#9e9e9e
+    style XVapix fill:#f5f5f5,stroke:#9e9e9e
+    style XAws fill:#f5f5f5,stroke:#9e9e9e
 ```
-
-The `remotefile` plugin will buffer frames in memory if an internet connection is not available. This means that you will not lose any frames if the device is offline for a short time. Do however note the [known issue](#known-issues) below affecting the startup of the workflow when no internet connection is available.
 
 ## Why Choose This Approach?
 
@@ -80,8 +106,8 @@ This approach makes timelapse functionality accessible to system integrators and
 
 ### FixedIT Data Agent Compatibility
 
-- **Minimum Data Agent version**: 1.0
-- **Required features**: Uses the `input.exec` and `output.remotefile` plugins. Uses the `TELEGRAF_DEBUG`, `HELPER_FILES_DIR` and `DEVICE_PROP_SERIAL` environment variables which are available in all FixedIT Data Agent versions.
+- **Minimum Data Agent version**: 1.5.0
+- **Required features**: Uses the `serializers.template` plugin which was added in FixedIT Data Agent 1.5.0. Uses the `input.exec` and `output.remotefile` plugins. Uses the `TELEGRAF_DEBUG`, `HELPER_FILES_DIR` and `DEVICE_PROP_*` environment variables which are available in all FixedIT Data Agent versions. Uses the `VAPIX_USERNAME` and `VAPIX_PASSWORD` environment variables which was added in FixedIT Data Agent v1.1.
 
 ## Create an S3 Bucket in AWS
 
@@ -147,22 +173,26 @@ After creating the user and setting up the permissions, create access keys follo
 
 1. **Configure FixedIT Data Agent variables:**
 
+   Click the three dots next to the FixedIT Data Agent application in the camera's "Apps" section and select "Settings". Then set the following parameters:
+   - `VAPIX Username`: The username for a viewer in the camera
+   - `VAPIX Password`: The password for a viewer in the camera
+
    Set the following environment variables in the `Extra env` parameter as a semicolon-separated list:
 
    ```txt
-   VAPIX_USER=your_vapix_username;VAPIX_PASS=your_vapix_password;AWS_ACCESS_KEY_ID=your_aws_access_key;AWS_SECRET_ACCESS_KEY=your_aws_secret_key;AWS_REGION=your_aws_region;S3_BUCKET=your_timelapse_bucket;CAPTURE_INTERVAL_SEC=300
+   AWS_ACCESS_KEY_ID=your_aws_access_key;AWS_SECRET_ACCESS_KEY=your_aws_secret_key;AWS_REGION=your_aws_region;S3_BUCKET=your_timelapse_bucket;CAPTURE_INTERVAL_SEC=300
    ```
 
    **Required variables:**
-   - `VAPIX_USER` / `VAPIX_PASS`: Camera authentication credentials
+   - `VAPIX_USERNAME` / `VAPIX_PASSWORD`: These are configured in the Data Agent settings and used to fetch the images using the network API
    - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`: AWS credentials for S3 access
    - `AWS_REGION`: AWS region (depends on your S3 bucket setup)
    - `S3_BUCKET`: Target S3 bucket name
    - `CAPTURE_INTERVAL_SEC`: Image capture interval in seconds (default: 300 = 5 minutes)
 
    **Optional variables:**
-   - `RESOLUTION`: Image resolution (optional - if not set, camera default will be used)
-   - `CAMERA_IP`: Camera IP address for image capture (optional - if not set, `localhost` will be used). If you want to use images from the camera that is running the FixedIT Data Agent, this does not need to be set.
+   - `RESOLUTION`: Image resolution (optional; if not set, camera default will be used)
+   - `CAMERA_IP`: Camera IP address for image capture (optional; if not set, `localhost` will be used). If you want to use images from the camera that is running the FixedIT Data Agent, this does not need to be set.
 
 2. **Upload the files to the FixedIT Data Agent**
 
@@ -231,38 +261,51 @@ If the AWS permissions are not enough, you should see an error like this in the 
 ### Image Capture Process
 
 1. **Exec Input Plugin**: Runs `axis_image_consumer.sh` at specified intervals
-2. **Image Processing**: Script fetches JPEG from camera's VAPIX API and encodes as base64
-3. **JSON Output**: Creates structured JSON with image data and metadata
-4. **S3 Upload**: remotefile plugin uploads each image as individual JSON file
+2. **Image Processing**: Script fetches JPEG from camera's VAPIX API and encodes as base64 for the `image_base64` field
+3. **JSON metric**: Exec plugin parses stdout into a Telegraf metric (string field + metadata)
+4. **S3 upload**: Two remotefile outputs write `timelapse-HH-MM-SS.jpg` (binary) and `timelapse-HH-MM-SS.json` (metadata) under the same folder
 
 ### AWS S3 Integration
 
-- **File Naming**: Uses template `DEVICE_SERIAL/YYYY-MM-DD/timelapse-HH-MM-SS.json`
-- **Data Format**: JSON with base64-encoded image and metadata
+- **File naming**: `${DEVICE_PROP_SERIAL}/YYYY-MM-DD/timelapse-HH-MM-SS.(jpg|json)` objects
+- **JPEG object**: Raw bytes (`image/jpeg`)
+- **JSON object**: Metadata file with image tags
 - **Access Control**: Uses AWS IAM credentials for authentication
 
-### Output File Format
+### Output file layout
 
-Each uploaded file contains a JSON object with the following structure:
+Each capture produces a pair of objects with the same path prefix and clock-based name:
+
+- **`*.jpg`**: The frame as a normal JPEG file.
+- **`*.json`**: Metadata only, for example:
 
 ```json
 {
-  "fields": {
-    "image_base64": "/9j/4AAQSkZJRgABAQAAAQABA...",
-    "length": 182812
-  },
+  "timestamp": 1691328000,
   "tags": {
-    "host": "device-hostname"
-  },
-  "timestamp": 1691328000
+    "host": "axis-b8a44f717321",
+    "area": "Europe",
+    "geography": "Sweden",
+    "region": "Lund",
+    "site": "Office",
+    "latitude": "55.714794",
+    "longitude": "13.214984",
+    "type": "Construction Site",
+    "resolution": "1920x1080",
+    "device_brand": "AXIS",
+    "device_model": "M3045-LVE",
+    "device_variant": "48mm",
+    "device_type": "Dome Camera",
+    "product_full_name": "AXIS M3045-LVE Dome Camera",
+    "device_serial": "B8A44F717321",
+    "firmware_version": "12.5.56",
+    "architecture": "aarch64",
+    "soc": "Axis Artpec-7",
+    "data_agent_version": "1.5.0",
+    "data_agent_start_time": "1760454197"
+  }
 }
 ```
-
-**Fields:**
-
-- `image_base64`: Base64-encoded JPEG image data (starts with `/9j/` for JPEG)
-- `length`: Size of the base64-encoded image data in characters
-- `timestamp`: Unix timestamp in seconds when the image was captured
 
 ### S3 Bucket Structure
 
@@ -272,11 +315,13 @@ The timelapse images are organized in the S3 bucket with the following structure
 s3://your-timelapse-bucket/
 ├── DEVICE_SERIAL_001/
 │   ├── 2025-08-06/
+│   │   ├── timelapse-10-38-33.jpg
 │   │   ├── timelapse-10-38-33.json
+│   │   ├── timelapse-10-38-37.jpg
 │   │   ├── timelapse-10-38-37.json
-│   │   ├── timelapse-10-38-42.json
 │   │   └── ...
 │   ├── 2025-08-07/
+│   │   ├── timelapse-09-15-30.jpg
 │   │   ├── timelapse-09-15-30.json
 │   │   └── ...
 │   └── ...
@@ -307,8 +352,8 @@ First, set up the environment variables:
 
 ```bash
 # Required variables (must be configured)
-export VAPIX_USER="your_vapix_username"
-export VAPIX_PASS="your_vapix_password"
+export VAPIX_USERNAME="your_vapix_username"
+export VAPIX_PASSWORD="your_vapix_password"
 export CAMERA_IP="your.camera.ip"
 
 export AWS_ACCESS_KEY_ID="your_access_key"
@@ -322,7 +367,10 @@ export HELPER_FILES_DIR="$(pwd)"
 # Set the capture interval in seconds.
 export CAPTURE_INTERVAL_SEC="60"
 
-# Set image resolution (optional - if not set, camera default will be used)
+# Device serial, used for the S3 path prefix
+export DEVICE_PROP_SERIAL="host-test"
+
+# Set image resolution (optional, otherwise camera default will be used)
 export RESOLUTION="1920x1080"
 
 # Enable debug mode (optional)
@@ -332,19 +380,15 @@ export TELEGRAF_DEBUG="true"
 Then run the test:
 
 ```bash
-# Test configuration
-telegraf --config timelapse-to-s3.conf --test
-
-# Run once to capture and upload a single image
-telegraf --config timelapse-to-s3.conf --once
-
 # Run continuously (use Ctrl+C to stop)
 telegraf --config timelapse-to-s3.conf
 ```
 
+Note that running `--once` will not work as expected since it will only run one of the outputs and either write the image or the metadata file, but not both. Running with `--test` should be avoided since it will print the whole base64 encoded image to the console.
+
 ## Known issues
 
-Although the `remotefile` output will buffer frames in memory for later upload if no internet connection is available, it seems like it is blocking the initialization of the workflow until it can connect to the S3 bucket the first time. This means that if the device boots up with no internet connection, the workflow will not start capturing frames until it has managed to connect to the S3 bucket at least once. This can be seen in the logs below:
+Although the `remotefile` output will buffer frames in memory for later upload if no internet connection is available, it is blocking the initialization of the workflow until it can connect to the S3 bucket the first time. This means that if the device boots up with no internet connection, the workflow will not start capturing frames until it has managed to connect to the S3 bucket at least once. This can be seen in the logs below:
 
 ![No internet connection will block the start of the e workflow](./.images/logs-offline-boot.png)
 

--- a/project-timelapse-s3/axis_image_consumer.sh
+++ b/project-timelapse-s3/axis_image_consumer.sh
@@ -5,31 +5,28 @@
 # =============================================================================
 #
 # PURPOSE:
-#   Fetches images from an Axis camera via VAPIX API and returns them as
-#   base64-encoded JSON for MQTT transmission.
+#   Fetches a JPEG from the camera VAPIX API and prints a JSON object containing
+#   the base64-encoded image and the optional resolution.
 #
 # INPUT VARIABLES:
-#   VAPIX_USER     - Username for camera authentication (default: root)
-#   VAPIX_PASS     - Password for camera authentication (default: pass)
-#   CAMERA_IP      - IP address of the Axis camera (default: 127.0.0.1)
-#   RESOLUTION     - Image resolution in format "widthxheight" (e.g., "1920x1080")
-#   TELEGRAF_DEBUG - Enable debug logging when set to "true"
+#   VAPIX_USERNAME  - Username for camera authentication (default: root)
+#   VAPIX_PASSWORD  - Password for camera authentication (default: pass)
+#   CAMERA_IP       - IP address or hostname of the Axis camera (default: 127.0.0.1)
+#   RESOLUTION      - Optional image resolution (e.g. 1920x1080) for the JPEG URL query;
+#                     if unset the camera uses its default resolution for the JPEG request.
+#   TELEGRAF_DEBUG  - Enable debug logging when set to "true"
 #   HELPER_FILES_DIR - Directory for debug log files
 #
 # OUTPUT:
-#   JSON string with format: {"image_base64":"<base64_data>","length":<size>}
-#   or error JSON: {"error":"<message>","image_base64":null,"length":0}
-#
-# USAGE:
-#   Called by mqtt_image_request_handler.sh as part of the MQTT image request
-#   pipeline. The script fetches images from the camera's CGI endpoint and
-#   encodes them for transmission over MQTT.
+#   Success: JSON with format {"image_base64":"<base64_data>","resolution":"<resolution>"}
+#   The resolution key is always present; when RESOLUTION is unset it is an empty string.
+#   Failure: {"error":"<message>","image_base64":null}
 #
 # =============================================================================
 
 # Configuration
-VAPIX_USER="${VAPIX_USER:-root}"
-VAPIX_PASS="${VAPIX_PASS:-pass}"
+VAPIX_USERNAME="${VAPIX_USERNAME:-root}"
+VAPIX_PASSWORD="${VAPIX_PASSWORD:-pass}"
 CAMERA_IP="${CAMERA_IP:-127.0.0.1}"
 
 # We use HTTP for the image fetch. Since the request is to localhost, this is quite safe.
@@ -68,10 +65,10 @@ fetch_image() {
     fi
 
     debug_log_file "Fetching image from: $url"
-    debug_log_file "Using credentials: $VAPIX_USER:****"
+    debug_log_file "Using credentials: $VAPIX_USERNAME:****"
 
     # Test connectivity first
-    test_response=$(curl -s --digest -u "${VAPIX_USER}:${VAPIX_PASS}" "$url" --head 2>&1)
+    test_response=$(curl -s --digest -u "${VAPIX_USERNAME}:${VAPIX_PASSWORD}" "$url" --head 2>&1)
     test_exit=$?
 
     if [ $test_exit -ne 0 ]; then
@@ -81,7 +78,7 @@ fetch_image() {
 
     # Fetch image with authentication and pipe directly to base64 encoding
     # This avoids storing binary data in shell variables which can corrupt it
-    encoded_data=$(curl -s --digest -u "${VAPIX_USER}:${VAPIX_PASS}" "$url" 2>/dev/null | openssl base64 -A)
+    encoded_data=$(curl -s --digest -u "${VAPIX_USERNAME}:${VAPIX_PASSWORD}" "$url" 2>/dev/null | openssl base64 -A)
     curl_exit=$?
 
     if [ $curl_exit -ne 0 ]; then
@@ -132,23 +129,26 @@ FETCH_EXIT=$?
 # Check if image fetch was successful
 if [ $FETCH_EXIT -ne 0 ] || [ -z "$IMAGE_BASE64" ]; then
     debug_log_file "Image fetch failed or returned empty data"
-    jq -n '{"error": "Failed to fetch or encode image", "image_base64": null, "length": 0}'
+    jq -n '{"error": "Failed to fetch or encode image", "image_base64": null}'
     exit 1
 fi
 
-# Create JSON output using herefile to avoid command line argument length limits
+# Build the JSON line Telegraf will parse....
+# A JPEG is hundreds of KB once base64-encoded, so we use a here-document instead of e.g.
+# passing the variable as an argument to `jq -n --arg img "$IMAGE_BASE64" '{image_base64:$img,...}'`.
+# On many systems each program invocation has a tight limit on total argument size.
+# Passing the entire base64 blob as argv to jq can fail with "argument list too long" errors.
 JSON_OUTPUT=$(cat <<EOF
-{"image_base64":"$IMAGE_BASE64","length":${#IMAGE_BASE64}}
+{"image_base64":"$IMAGE_BASE64","resolution":"${RESOLUTION:-}"}
 EOF
 )
 
 # Validate JSON using jq
-if command -v jq >/dev/null 2>&1; then
-    if echo "$JSON_OUTPUT" | jq . >/dev/null 2>&1; then
-        debug_log_file "JSON validation successful"
-    else
-        debug_log_file "JSON validation failed"
-    fi
+if echo "$JSON_OUTPUT" | jq . >/dev/null 2>&1; then
+    debug_log_file "JSON validation successful"
+else
+    echo "axis_image_consumer.sh: JSON validation failed: invalid JSON payload (jq parse error)" >&2
+    exit 1
 fi
 
 # Log the actual JSON size

--- a/project-timelapse-s3/test_scripts/README.md
+++ b/project-timelapse-s3/test_scripts/README.md
@@ -4,7 +4,7 @@ This directory contains scripts for testing and viewing the timelapse system.
 
 ## Timelapse Viewer
 
-The `timelapse_viewer.py` script allows you to view timelapse videos created by the FixedIT Data Agent timelapse system. It fetches the json files from AWS S3, extracts the base64 encoded image, and displays them as a video or saves them as an MP4 file.
+The `timelapse_viewer.py` script allows you to view timelapse videos using the images uploaded by the FixedIT Data Agent timelapse system. It fetches the metadata and image files from AWS S3, and displays them as a video or saves them as an MP4 file.
 
 ### Use the viewer
 

--- a/project-timelapse-s3/test_scripts/requirements.txt
+++ b/project-timelapse-s3/test_scripts/requirements.txt
@@ -1,5 +1,5 @@
-boto3==1.40.3
-click==8.2.1
-opencv-python==4.12.0.88
-pillow==11.3.0
-tqdm==4.67.1
+boto3
+click
+opencv-python
+pillow
+tqdm

--- a/project-timelapse-s3/test_scripts/timelapse_viewer.py
+++ b/project-timelapse-s3/test_scripts/timelapse_viewer.py
@@ -5,11 +5,10 @@ This module provides functionality to view and analyze timelapse videos
 created by the FixedIT Data Agent and stored in AWS S3.
 """
 
-import base64
 import io
 import json
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterator, List, Optional, Tuple
 
 import boto3
@@ -50,8 +49,8 @@ def handle_s3_client_error(e: ClientError, bucket: str) -> None:
 class TimelapseViewer:
     """A viewer for timelapse videos stored in AWS S3.
 
-    This class provides functionality to fetch, decode, and display timelapse
-    images stored as JSON files in S3 buckets.
+    This class provides functionality to fetch and display timelapse
+    images stored as JPEG files and JSON metadata in S3 buckets.
     """
 
     def __init__(self, bucket_name: str, aws_region: Optional[str] = None):
@@ -63,6 +62,10 @@ class TimelapseViewer:
         """
         self.bucket_name = bucket_name
         self.s3_client = boto3.client("s3", region_name=aws_region)
+
+    @staticmethod
+    def _jpeg_key_from_metadata_key(json_key: str) -> str:
+        return str(PurePosixPath(json_key).with_suffix(".jpg"))
 
     def _paginated_s3_request(self, **request_params) -> Iterator[dict]:
         """Generate S3 API responses across all pages.
@@ -142,7 +145,7 @@ class TimelapseViewer:
             date: Optional date filter in YYYY-MM-DD format
 
         Returns:
-            List of S3 keys for timelapse JSON files
+            List of S3 keys for timelapse metadata JSON files
         """
         prefix = f"{device_serial}/"
         if date:
@@ -153,7 +156,8 @@ class TimelapseViewer:
         # Use pagination helper to get all objects
         for obj in self._paginated_s3_list(Bucket=self.bucket_name, Prefix=prefix):
             key = obj["Key"]
-            if "timelapse-" in key and key.endswith(".json"):
+            lower_k = key.lower()
+            if "timelapse-" in lower_k and lower_k.endswith(".json"):
                 timelapse_files.append(key)
 
         # Sort by filename (which includes timestamp)
@@ -161,69 +165,56 @@ class TimelapseViewer:
         return timelapse_files
 
     def fetch_image_from_s3(self, s3_key: str) -> Tuple[Image.Image, datetime]:
-        """Fetch a single image from S3 and decode it.
+        """Load one frame from a metadata key and its paired JPEG object.
 
         Args:
-            s3_key: The S3 key for the JSON file containing the image
+            s3_key: Object key for a timelapse-*.json metadata file.
 
         Returns:
             Tuple of (PIL Image, UTC datetime timestamp)
 
         Raises:
-            ValueError: If JSON structure is invalid or image data is corrupted
+            ValueError: If keys, JSON structure, or image bytes are invalid
         """
-        # Download the JSON file
-        response = self.s3_client.get_object(Bucket=self.bucket_name, Key=s3_key)
-        json_data = json.loads(response["Body"].read().decode("utf-8"))
-
-        # Validate required JSON structure
-        if "fields" not in json_data:
-            raise ValueError(f"Missing 'fields' key in JSON data from {s3_key}")
-
-        fields = json_data["fields"]
-        if "image_base64" not in fields:
-            raise ValueError(f"Missing 'image_base64' key in fields from {s3_key}")
-
-        # Extract base64 image data
-        image_base64 = fields["image_base64"]
-
-        # Validate that image_base64 is not empty
-        if not image_base64:
-            raise ValueError(f"Empty image_base64 data in {s3_key}")
-
-        # Decode base64 image data
-        try:
-            image_data = base64.b64decode(image_base64)
-        except Exception as e:
-            raise ValueError(f"Invalid base64 data in {s3_key}: {e}") from e
-
-        # Convert to PIL Image
-        try:
-            image = Image.open(io.BytesIO(image_data))
-        except Exception as e:
-            raise ValueError(f"Failed to decode image data from {s3_key}: {e}") from e
-
-        # Extract UTC timestamp from JSON timestamp field (nanoseconds)
-        # The timestamp is at the root level, not inside fields
-        if "timestamp" not in json_data:
+        lower_k = s3_key.lower()
+        if not lower_k.endswith(".json"):
             raise ValueError(
-                f"Missing 'timestamp' field in JSON data from {s3_key}. "
-                f"JSON structure: {json_data.keys()}"
+                f"Expected a timelapse metadata key ending in .json, got: {s3_key}"
             )
 
-        # Convert timestamp to datetime
-        timestamp_s = json_data["timestamp"]
+        meta_resp = self.s3_client.get_object(Bucket=self.bucket_name, Key=s3_key)
+        meta = json.loads(meta_resp["Body"].read().decode("utf-8"))
 
-        # Validate that timestamp is a number
+        # Get the timestamp, validate it and convert to UTC datetime
+        if "timestamp" not in meta:
+            raise ValueError(f"Missing 'timestamp' in metadata {s3_key}")
+        timestamp_s = meta["timestamp"]
         if not isinstance(timestamp_s, (int, float)):
             raise ValueError(
                 f"Invalid timestamp type in {s3_key}: expected number, "
                 f"got {type(timestamp_s)}"
             )
+        timestamp = datetime.fromtimestamp(float(timestamp_s), tz=timezone.utc)
 
-        timestamp = datetime.fromtimestamp(timestamp_s, tz=timezone.utc)
+        # Get the JPEG image (stored as a separate object)
+        jpg_key = self._jpeg_key_from_metadata_key(s3_key)
+        try:
+            img_resp = self.s3_client.get_object(Bucket=self.bucket_name, Key=jpg_key)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code == "NoSuchKey":
+                raise ValueError(
+                    f"No paired JPEG for {s3_key} (expected object {jpg_key})"
+                ) from e
+            raise
 
-        return image, timestamp
+        payload = img_resp["Body"].read()
+        try:
+            image = Image.open(io.BytesIO(payload))
+        except Exception as e:
+            raise ValueError(f"Failed to decode JPEG data from {jpg_key}: {e}") from e
+
+        return image.convert("RGB"), timestamp
 
     def _prepare_image_for_display(
         self, img: Image.Image, timestamp: datetime

--- a/project-timelapse-s3/timelapse-to-s3.conf
+++ b/project-timelapse-s3/timelapse-to-s3.conf
@@ -1,7 +1,10 @@
 # FixedIT Data Agent Configuration for Timelapse with AWS S3
 #
 # This configuration captures images from an AXIS device and uploads them to AWS S3
-# for timelapse video generation. Images are encoded as base64 in JSON format.
+# for timelapse video generation. JPEG bytes are embedded as base64 in the exec JSON
+# metric; outputs.remotefile decodes them with data_format=template (see Telegraf docs)
+# so each capture produces two S3 objects with the same basename: a binary .jpg
+# and a small .json metadata file.
 #
 # Usage: Upload this file to the FixedIT Data Agent and enable it
 # along with the required environment variables.
@@ -10,6 +13,33 @@
   flush_interval = "10s"
   debug = ${TELEGRAF_DEBUG}
   interval = "${CAPTURE_INTERVAL_SEC}s"
+
+[global_tags]
+  # Geo / site tags (from Data Agent UI; empty if unset).
+  area = "${AREA:-}"
+  geography = "${GEOGRAPHY:-}"
+  region = "${REGION:-}"
+  site = "${SITE:-}"
+  latitude = "${DEVICE_LOCATION_LATITUDE:-}"
+  longitude = "${DEVICE_LOCATION_LONGITUDE:-}"
+
+  # Type tag (from Data Agent UI; empty if unset).
+  type = "${TYPE:-}"
+
+  # Device identity (set on device by the Data Agent).
+  device_brand = "${DEVICE_PROP_BRAND:-}"
+  device_model = "${DEVICE_PROP_MODEL:-}"
+  device_variant = "${DEVICE_PROP_VARIANT:-}"
+  device_type = "${DEVICE_PROP_TYPE:-}"
+  product_full_name = "${DEVICE_PROP_FULL_NAME:-}"
+  device_serial = "${DEVICE_PROP_SERIAL:-}"
+  firmware_version = "${DEVICE_PROP_FIRMWARE:-}"
+  architecture = "${DEVICE_PROP_ARCH:-}"
+  soc = "${DEVICE_PROP_SOC:-}"
+
+  # Application info (automatically set on device).
+  data_agent_version = "${APP_VERSION:-}"
+  data_agent_start_time = "${APP_START_TIME:-}"
 
 [[inputs.exec]]
   # Run the script that captures the image from the camera and embeds it as a base64 encoded value.
@@ -21,6 +51,7 @@
   # since Telegraf's JSON parser by default only includes numeric fields.
   data_format = "json"
   json_string_fields = ["image_base64", "error"]
+  tag_keys = ["resolution"]
 
   # Set the name of the metric to "timelapse_image"
   name_override = "timelapse_image"
@@ -29,12 +60,12 @@
   # Only upload metrics with the name "timelapse_image"
   namepass = ["timelapse_image"]
 
-  # Configure the upload bucket and file path.
-  # File naming pattern: DEVICE_SERIAL/YYYY-MM-DD/timelapse-HH-MM-SS.json.
-  # File will be saved as JSON with the base64 encoded image in the message.
+  # Binary JPEG: ${DEVICE_PROP_SERIAL}/YYYY-MM-DD/timelapse-HH-MM-SS.jpg
+  # The function call in the template serializer converts the base64 string back to binary.
   remote = "s3,provider=AWS,access_key_id=${AWS_ACCESS_KEY_ID},secret_access_key=${AWS_SECRET_ACCESS_KEY},region=${AWS_REGION}:${S3_BUCKET}"
-  files = ['${DEVICE_PROP_SERIAL}/{{.Time.Format "2006-01-02"}}/timelapse-{{.Time.Format "15-04-05"}}.json']
-  data_format = "json"
+  files = ['${DEVICE_PROP_SERIAL}/{{.Time.Format "2006-01-02"}}/timelapse-{{.Time.Format "15-04-05"}}.jpg']
+  data_format = "template"
+  template = '{{ .Field "image_base64" | b64dec }}'
 
   # Configure the cache settings for the upload.
   #
@@ -57,4 +88,20 @@
   # Controls how long the plugin keeps internal state (serializers, modification timestamps)
   # for each file after its last write. Since we use unique files for each image,
   # we can clean up internal state much faster - no point keeping serializers for old files.
+  forget_files_after = "1s"
+
+[[outputs.remotefile]]
+  namepass = ["timelapse_image"]
+
+  # Metadata JSON with all tags and the timestamp field (image field not included
+  # since it is a field, not a tag)
+  remote = "s3,provider=AWS,access_key_id=${AWS_ACCESS_KEY_ID},secret_access_key=${AWS_SECRET_ACCESS_KEY},region=${AWS_REGION}:${S3_BUCKET}"
+  files = ['${DEVICE_PROP_SERIAL}/{{.Time.Format "2006-01-02"}}/timelapse-{{.Time.Format "15-04-05"}}.json']
+  data_format = "template"
+  template = '{{ dict "timestamp" (.Time.Unix) "tags" .Tags | toJson }}'
+
+  # See comments for the first remotefile output above.
+  cache_write_back = "0s"
+  final_write_timeout = "5s"
+  cache_max_size = "5MB"
   forget_files_after = "1s"


### PR DESCRIPTION
- Use the template serializer to upload JPG images instead of b64 files
- Bump to use the new vapix creds added in v1.1
- Unpin the requirements file for the python script since we don't have strict requirements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the timelapse S3 object format (from a single base64 JSON object to paired `.jpg` + `.json` objects) and updates credential env var names, which can break existing deployments and viewer tooling if not migrated.
> 
> **Overview**
> Switches the `project-timelapse-s3` pipeline to write **two S3 objects per capture** using Telegraf `serializers.template`: a binary `timelapse-*.jpg` (base64 decoded in the template) plus a lightweight `timelapse-*.json` metadata file containing timestamp and tags.
> 
> Updates the capture script and docs to use the newer `VAPIX_USERNAME`/`VAPIX_PASSWORD` variables, adds richer `global_tags` metadata in the Telegraf config, and updates the Python viewer to load frames from the paired JPEG object instead of decoding base64 from JSON. Also relaxes Python `requirements.txt` version pinning and refreshes diagrams/setup guidance accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afeebd9a530d23c1dde75e4a593ce2594db5d747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated timelapse pipeline docs to describe paired JPEG + JSON metadata storage, revised flow diagram, bucket layout, and local testing instructions.
  * Renamed camera credential variables to VAPIX_USERNAME / VAPIX_PASSWORD throughout docs.

* **Configuration**
  * Timelapse pipeline now uploads two S3 objects per capture: decoded binary .jpg and a companion .json metadata file.

* **Behavior**
  * Viewer and capture scripts now expect paired .jpg/.json outputs, include a resolution field in success JSON, and produce a consistent error JSON shape.

* **Chores**
  * Relaxed pinned versions in test scripts requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fixedit-ai/fixedit-data-agent-examples/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->