### PR TITLE
Fix incorrect default in README

### DIFF
--- a/project-timelapse-s3/README.md
+++ b/project-timelapse-s3/README.md
@@ -194,7 +194,7 @@ After creating the user and setting up the permissions, create access keys follo
    - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`: AWS credentials for S3 access
    - `AWS_REGION`: AWS region (depends on your S3 bucket setup)
    - `S3_BUCKET`: Target S3 bucket name
-   - `CAPTURE_INTERVAL_SEC`: Image capture interval in seconds (default: 300 = 5 minutes)
+   - `CAPTURE_INTERVAL_SEC`: Image capture interval in seconds
 
    **Optional variables:**
    - `RESOLUTION`: Image resolution (optional; if not set, camera default will be used)


### PR DESCRIPTION
The readme stated a default value for a variable that is required (no default)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 934bba9f2c47b4649344192d1859b70c84e5ebab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the documentation for the capture interval setting without specifying a default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->